### PR TITLE
Removed auto writing of demo/current day data

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,9 +1,10 @@
 {
     "appKeys": {},
     "capabilities": [
-        ""
+        "health"
     ],
-    "companyName": "hi.imsean@yahoo.com",
+    "companyName": "bnichols@gmail.com",
+    "enableMultiJS": false,
     "longName": "HealthNET",
     "projectType": "native",
     "resources": {
@@ -48,6 +49,10 @@
     },
     "sdkVersion": "3",
     "shortName": "HealthNET",
+    "targetPlatforms": [
+        "aplite",
+        "basalt"
+    ],
     "uuid": "7273f7b5-887d-41ee-a319-66d604447314",
     "versionLabel": "1.0",
     "watchapp": {

--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,7 @@ static int getCurrentDayNumber(){
 static void saveTodayData() {
     int currentDay = getCurrentDayNumber();
     APP_LOG(APP_LOG_LEVEL_INFO, "Current Day: %d", currentDay);
-	persist_write_data(currentDay, &today, sizeof(today));
+	//persist_write_data(currentDay, &today, sizeof(today));
     weekData[0] = today;
 	//saveDateDataToStorage(currentDay, &today, sizeof(today));
 }
@@ -205,7 +205,7 @@ static void loadDemoData(){
         weekData[i].mood = (rand() % (5 + 1 - 1) + 1);
         weekData[i].sleepSeconds = (rand() % (36000 + 1 - 0) + 0);
         weekData[i].steps = (rand() % (6000 + 1 - 0) + 0);
-        persist_write_data(currentDay - (i+1), &weekData[i], sizeof(weekData[i]));
+        //persist_write_data(currentDay - (i+1), &weekData[i], sizeof(weekData[i]));
         APP_LOG(APP_LOG_LEVEL_INFO, "Random Data: m:%d, s:%d, ste:%d",weekData[i].mood, weekData[i].sleepSeconds, weekData[i].steps);
     }
 
@@ -216,7 +216,7 @@ static void readDemoData(){
     int currentDay = getCurrentDayNumber();
 
         for(int i = 0; i < 6; i++){
-        persist_read_data(currentDay - (i+1), &weekData[i], sizeof(weekData[i]));
+        //persist_read_data(currentDay - (i+1), &weekData[i], sizeof(weekData[i]));
         APP_LOG(APP_LOG_LEVEL_INFO, "Week data %d: seconds:%d mood:%d", currentDay - (i+1), weekData[i].sleepSeconds, weekData[i].mood);
     }
 }


### PR DESCRIPTION
This will keep the app from backfilling persistent storage with demo data every time you run it. The app will still load demo data, but will not save it to persistent storage.
